### PR TITLE
docker/build-push-action requires all lowercase

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -113,11 +113,13 @@ runs:
 
     - name: Build and push ${{ inputs.package }} Docker image
       if: steps.check.outputs.build == 'true'
+      env:
+        tags: (ghcr.io/${{ github.repository }}/${{ inputs.package }}:${{ inputs.tag }}).toLowerCase()
       uses: docker/build-push-action@v3
       with:
         context: ./${{ inputs.package }}/
         push: true
-        tags: ghcr.io/${{ github.repository }}/${{ inputs.package }}:${{ inputs.tag }}
+        tags: ${{ env.tags }}
         cache-from: type=gha
         cache-to: type=gha,mode=max
 

--- a/action.yml
+++ b/action.yml
@@ -111,15 +111,20 @@ runs:
         username: ${{ github.actor }}
         password: ${{ inputs.token }}
 
+    - name: Force lowercase for Docker
+      shell: bash
+      id: lowercase
+      run: |
+        TAGS=$( echo "ghcr.io/${{ github.repository }}/${{ inputs.package }}:${{ inputs.tag }}" | tr '[:upper:]' '[:lower:]' )
+        echo "tags=${TAGS}" >> $GITHUB_OUTPUT
+
     - name: Build and push ${{ inputs.package }} Docker image
       if: steps.check.outputs.build == 'true'
-      env:
-        tags: (ghcr.io/${{ github.repository }}/${{ inputs.package }}:${{ inputs.tag }}).toLowerCase()
       uses: docker/build-push-action@v3
       with:
         context: ./${{ inputs.package }}/
         push: true
-        tags: ${{ env.tags }}
+        tags: ${{ steps.lowercase.outputs.tags }}
         cache-from: type=gha
         cache-to: type=gha,mode=max
 


### PR DESCRIPTION
docker/build-push-action@v3 is failing during tests from my personal repo (org=DerekRoberts).  Change Action to make sure lowercase only. GitHub doesn't treat them any differently.