### PR TITLE
feat: add build_file parameter

### DIFF
--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -8,80 +8,51 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  # retags:
-  #   permissions:
-  #     packages: write
-  #   runs-on: ubuntu-22.04
-  #   strategy:
-  #     matrix:
-  #       package: [backend, database, frontend]
-  #       include:
-  #         - package: backend
-  #           triggers: ('backend/')
-  #         - package: database
-  #           triggers: ('database/')
-  #         - package: frontend
-  #           triggers: ('frontend/')
-  #   steps:
-  #     - uses: actions/checkout@v3
-  #     - name: Test Retags
-  #       uses: ./
-  #       with:
-  #         package: ${{ matrix.package }}
-  #         tag: ${{ github.event.number }}
-  #         tag_fallback: test
-  #         repository: bcgov/nr-quickstart-typescript
-  #         token: ${{ secrets.GITHUB_TOKEN }}
-
-  # builds:
-  #   permissions:
-  #     packages: write
-  #   runs-on: ubuntu-22.04
-  #   strategy:
-  #     matrix:
-  #       package: [backend, database, frontend]
-  #   steps:
-  #     - uses: actions/checkout@v3
-  #     - name: Test Builds
-  #       uses: ./
-  #       with:
-  #         package: ${{ matrix.package }}
-  #         build_context: ${{ matrix.build_file }}
-  #         build_file: ${{ matrix.build_file }}
-  #         tag: ${{ github.event.number }}
-  #         repository: bcgov/nr-quickstart-typescript
-  #         token: ${{ secrets.GITHUB_TOKEN }}
-
-  fom:
+  # Anything can be retagged if a fallback image exists (e.g. test)
+  retag:
     permissions:
       packages: write
+    name: Retag
     runs-on: ubuntu-22.04
-    strategy:
-      matrix:
-        package: [fom-admin, fom-api, db, fom-public]
-        include:
-          - package: fom-admin
-            build_context: .
-            build_file: admin/Dockerfile
-            triggers: ('admin/')
-          - package: fom-api
-            build_context: .
-            build_file: api/Dockerfile
-            triggers: ('api/')
-          - package: db
-            triggers: ('db/')
-          - package: fom-public
-            build_context: .
-            build_file: public/Dockerfile
-            triggers: ('public/')
     steps:
       - uses: actions/checkout@v3
-      - name: Test Builds
-        uses: ./
+      - uses: ./
         with:
-          package: ${{ matrix.package }}
-          build_context: ${{ matrix.build_context }}
-          build_file: ${{ matrix.build_file }}
+          package: backend
+          repository: bcgov/nr-quickstart-typescript
+          tag: ${{ github.event.number }}
+          tag_fallback: test
+          token: ${{ secrets.GITHUB_TOKEN }}
+          triggers: ('backend/')
+
+  # QuickStart apps build from the same dirs as their Dockerfiles
+  basic:
+    permissions:
+      packages: write
+    name: Basic
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ./
+        with:
+          package: frontend
+          repository: bcgov/nr-quickstart-typescript
+          tag: ${{ github.event.number }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+  # FOM apps build from repo root, one above their Dockerfiles
+  advanced:
+    permissions:
+      packages: write
+    name: Advanced
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ./
+        with:
+          package: api
+          build_context: .
+          build_file: api/Dockerfile
           repository: bcgov/nr-fom
           tag: ${{ github.event.number }}
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -8,44 +8,80 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  retags:
-    permissions:
-      packages: write
-    runs-on: ubuntu-22.04
-    strategy:
-      matrix:
-        package: [backend, database, frontend]
-        include:
-          - package: backend
-            triggers: ('backend/')
-          - package: database
-            triggers: ('database/')
-          - package: frontend
-            triggers: ('frontend/')
-    steps:
-      - uses: actions/checkout@v3
-      - name: Test Retags
-        uses: ./
-        with:
-          package: ${{ matrix.package }}
-          tag: ${{ github.event.number }}
-          tag_fallback: test
-          repository: bcgov/nr-quickstart-typescript
-          token: ${{ secrets.GITHUB_TOKEN }}
+  # retags:
+  #   permissions:
+  #     packages: write
+  #   runs-on: ubuntu-22.04
+  #   strategy:
+  #     matrix:
+  #       package: [backend, database, frontend]
+  #       include:
+  #         - package: backend
+  #           triggers: ('backend/')
+  #         - package: database
+  #           triggers: ('database/')
+  #         - package: frontend
+  #           triggers: ('frontend/')
+  #   steps:
+  #     - uses: actions/checkout@v3
+  #     - name: Test Retags
+  #       uses: ./
+  #       with:
+  #         package: ${{ matrix.package }}
+  #         tag: ${{ github.event.number }}
+  #         tag_fallback: test
+  #         repository: bcgov/nr-quickstart-typescript
+  #         token: ${{ secrets.GITHUB_TOKEN }}
 
-  builds:
+  # builds:
+  #   permissions:
+  #     packages: write
+  #   runs-on: ubuntu-22.04
+  #   strategy:
+  #     matrix:
+  #       package: [backend, database, frontend]
+  #   steps:
+  #     - uses: actions/checkout@v3
+  #     - name: Test Builds
+  #       uses: ./
+  #       with:
+  #         package: ${{ matrix.package }}
+  #         build_context: ${{ matrix.build_file }}
+  #         build_file: ${{ matrix.build_file }}
+  #         tag: ${{ github.event.number }}
+  #         repository: bcgov/nr-quickstart-typescript
+  #         token: ${{ secrets.GITHUB_TOKEN }}
+
+  fom:
     permissions:
       packages: write
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        package: [backend, database, frontend]
+        package: [fom-admin, fom-api, db, fom-public]
+        include:
+          - package: fom-admin
+            build_context: .
+            build_file: admin/Dockerfile
+            triggers: ('admin/')
+          - package: fom-api
+            build_context: .
+            build_file: api/Dockerfile
+            triggers: ('api/')
+          - package: db
+            triggers: ('db/')
+          - package: fom-public
+            build_context: .
+            build_file: public/Dockerfile
+            triggers: ('public/')
     steps:
       - uses: actions/checkout@v3
       - name: Test Builds
         uses: ./
         with:
           package: ${{ matrix.package }}
+          build_context: ${{ matrix.build_context }}
+          build_file: ${{ matrix.build_file }}
+          repository: bcgov/nr-fom
           tag: ${{ github.event.number }}
-          repository: bcgov/nr-quickstart-typescript
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -130,6 +130,41 @@ jobs:
           triggers: ('frontend/')
 ```
 
+# Example, Single Build with build_context and build_file
+
+Build an image overriding the build context and the build file, which is the Dockerfile.
+
+Create or modify a GitHub workflow, like below.  E.g. `./github/workflows/pr-open.yml`
+
+```yaml
+name: Pull Request
+
+on:
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  builds:
+    permissions:
+      packages: write
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v3
+      - name: Builds
+        uses: bcgov-nr/action-conditional-container-builder@v1.0.0
+        with:
+          package: frontend
+          build_context: ./
+          build_file: subdir/Dockerfile
+          tag: ${{ github.event.number }}
+          tag_fallback: test
+          token: ${{ secrets.GITHUB_TOKEN }}
+          triggers: ('frontend/')
+```
+
 # Example, Matrix Build
 
 Build from multiple subfolders with Dockerfile in them.  This time an outside repository is used.  Runs on pull requests (PRs).

--- a/action.yml
+++ b/action.yml
@@ -60,7 +60,7 @@ runs:
           echo "build_context=${{ inputs.build_context }}" >> $GITHUB_OUTPUT
         fi
 
-        # Use ${{ inputs.package}/Dockerfile as build_file unless an override has been provided
+        # Use inputs.package/Dockerfile as build_file unless an override has been provided
         if [ -z ${{ inputs.build_file }} ]; then
           echo "build_file=${{ inputs.package }}/Dockerfile" >> $GITHUB_OUTPUT
         else

--- a/action.yml
+++ b/action.yml
@@ -22,9 +22,9 @@ inputs:
   triggers:
     description: Paths used to trigger a build; e.g. ('./backend/', './frontend/)
   build_context:
-    description: Sets the context build to be using the package parameter as the name of the folder where the code is
+    description: Build context, not required for self-contained package/default directory
   build_file:
-    description: Sets the Dockerfile being built, not required for Dockerfiles in the package/default folder
+    description: Dockerfile with path, not required for self-contained package/default directory
 
   ### Usually a bad idea / not recommended
   diff_branch:

--- a/action.yml
+++ b/action.yml
@@ -23,6 +23,8 @@ inputs:
     description: Paths used to trigger a build; e.g. ('./backend/', './frontend/)
   build_context:
     description: Sets the context build to be using the package parameter as the name of the folder where the code is
+  build_file:
+    description: Sets the Dockerfile being built, not required for Dockerfiles in the package/default folder
 
   ### Usually a bad idea / not recommended
   diff_branch:
@@ -56,6 +58,13 @@ runs:
           echo "build_context=${{ inputs.package }}" >> $GITHUB_OUTPUT
         else
           echo "build_context=${{ inputs.build_context }}" >> $GITHUB_OUTPUT
+        fi
+
+        # Use ${{ inputs.package}/Dockerfile as build_file unless an override has been provided
+        if [ -z ${{ inputs.build_file }} ]; then
+          echo "build_file=${{ inputs.package }}/Dockerfile" >> $GITHUB_OUTPUT
+        else
+          echo "build_file=${{ inputs.build_file }}" >> $GITHUB_OUTPUT
         fi
 
         # Bug - Docker build hates images with capital letters
@@ -136,6 +145,7 @@ runs:
       uses: docker/build-push-action@v4
       with:
         context: ${{ steps.vars.outputs.build_context }}
+        file: ${{ steps.vars.outputs.build_file }}
         push: true
         tags: ${{ steps.vars.outputs.tags }}
         cache-from: type=gha


### PR DESCRIPTION
Manually specify build_file to support different build contexts and build files.  Makes the tool less opinionated and more flexible.

E.g. Build from root, Dockerfile in subdir.

From readme:
```
  build_file:
    description: Dockerfile with path, not required for self-contained 
```