### PR TITLE
Use docker buildx imagetools to check tag_fallback

### DIFF
--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -19,7 +19,6 @@ jobs:
       - uses: ./
         with:
           package: backend
-          repository: bcgov/nr-quickstart-typescript
           tag: ${{ github.event.number }}
           tag_fallback: test
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/action.yml
+++ b/action.yml
@@ -79,7 +79,7 @@ runs:
         # Check for builds
 
         # Build if an override repository was provided
-        if [ "${{ inputs.repository }}" != ${{ github.repositor }}" ]; then
+        if [ "${{ inputs.repository }}" != "${{ github.repository }}" ]; then
           echo "Build triggered on override repository"
           echo "triggered=true" >> $GITHUB_OUTPUT
           exit 0

--- a/action.yml
+++ b/action.yml
@@ -88,12 +88,11 @@ runs:
         fi
 
         # Build if tag_fallback is no good (requires a valid container)
-        TOKEN=$(curl -s https://ghcr.io/token\?scope\="repository:${{ inputs.repository }}/${{ inputs.package }}:pull" | jq -r .token)
-        URL="https://ghcr.io/v2/${{ inputs.repository }}/${{ inputs.package }}/manifests/${{ inputs.tag_fallback }}"
-        if [ $(curl -ILso /dev/null -w "%{http_code}" -H "Authorization: Bearer ${TOKEN}" "${URL}") -ne 200 ]
+        if [ $(docker buildx imagetools inspect ghcr.io/${{ inputs.repository }}/${{ inputs.package }}:${{ inputs.tag_fallback }} > /dev/null) -ne 0 ]
         then
             # Output triggered=true for next steps
             echo "Build triggered.  Fallback tag (tag_fallback) not usable."
+            echo "Manifest checked for: ghcr.io/${{ inputs.repository }}/${{ inputs.package }}:${{ inputs.tag_fallback }}"
             echo "triggered=true" >> $GITHUB_OUTPUT
             exit 0
         fi

--- a/action.yml
+++ b/action.yml
@@ -78,11 +78,18 @@ runs:
       run: |
         # Check for builds
 
-        # Build if no tag_fallback, no triggers or using an override repository
-        if [ ! -z "${{ inputs.repository }}" ]||[ -z "${{ inputs.tag_fallback }}" ]||[ -z "${{ inputs.triggers }}" ]; then
-          echo "Build triggered based on inputs.  Possible reasons:"
-          echo " a) repository override provided"
-          echo " b) tag_fallback or triggers not provided"
+        # Build if an override repository was provided
+        if [ "${{ inputs.repository }}" != ${{ github.repositor }}" ]; then
+          echo "Build triggered on override repository"
+          echo "triggered=true" >> $GITHUB_OUTPUT
+          exit 0
+        fi
+
+        # Build if no tag_fallback or no triggers
+        if [ -z "${{ inputs.tag_fallback }}" ]||[ -z "${{ inputs.triggers }}" ]; then
+          echo "Build triggered with possible reasons:"
+          echo "  a) tag_fallback provided"
+          echo "  b) triggers not provided"
           echo "triggered=true" >> $GITHUB_OUTPUT
           exit 0
         fi


### PR DESCRIPTION
Builds were happening even when nothing had changed and a valid fallback was provided.  Something probably changed, because the previous image check just stopped working.

Resolves https://github.com/bcgov/quickstart-openshift/issues/1025.