### PR TITLE
Better handling of fallback not existing

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -93,14 +93,17 @@ runs:
           echo "triggered=true" >> $GITHUB_OUTPUT
           exit 0
 
-        # Build if tag_fallback is no good (requires a valid container)
-        elif [ $(docker buildx imagetools inspect ghcr.io/${{ inputs.repository }}/${{ inputs.package }}:${{ inputs.tag_fallback }} > /dev/null) -ne 0 ]
-        then
-            # Output triggered=true for next steps
-            echo "Build triggered.  Fallback tag (tag_fallback) not usable."
-            echo "Manifest checked for: ghcr.io/${{ inputs.repository }}/${{ inputs.package }}:${{ inputs.tag_fallback }}"
-            echo "triggered=true" >> $GITHUB_OUTPUT
-            exit 0
+        else
+          # Build if tag_fallback is no good (requires a valid container)
+          docker buildx imagetools inspect ghcr.io/${{ inputs.repository }}/${{ inputs.package }}:${{ inputs.tag_fallback }} > /dev/null 2>&1
+          if [ $? -ne 0 ]
+          then
+              # Output triggered=true for next steps
+              echo "Build triggered.  Fallback tag (tag_fallback) not usable."
+              echo "Manifest checked for: ghcr.io/${{ inputs.repository }}/${{ inputs.package }}:${{ inputs.tag_fallback }}"
+              echo "triggered=true" >> $GITHUB_OUTPUT
+              exit 0
+          fi
         fi
 
         # Build if changed files (git diff) match triggers

--- a/action.yml
+++ b/action.yml
@@ -92,10 +92,9 @@ runs:
           echo "  b) triggers not provided"
           echo "triggered=true" >> $GITHUB_OUTPUT
           exit 0
-        fi
 
         # Build if tag_fallback is no good (requires a valid container)
-        if [ $(docker buildx imagetools inspect ghcr.io/${{ inputs.repository }}/${{ inputs.package }}:${{ inputs.tag_fallback }} > /dev/null) -ne 0 ]
+        elif [ $(docker buildx imagetools inspect ghcr.io/${{ inputs.repository }}/${{ inputs.package }}:${{ inputs.tag_fallback }} > /dev/null) -ne 0 ]
         then
             # Output triggered=true for next steps
             echo "Build triggered.  Fallback tag (tag_fallback) not usable."


### PR DESCRIPTION
If tag_fallback isn't specified it will trigger the build. So there is no need to check if that tag exists.

Changed the way the fallback image check works. Now The command is run with all output and error sent to /dev/null. Then using the $? variable which will be 0 if found or 1 for other errors.

GitHub has a quirk. If NO packages exist for a repository it returns 403 instead of 401 not found.