### PR TITLE
bug: disable buildx provenance

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -166,6 +166,7 @@ runs:
         cache-from: type=gha
         cache-to: type=gha,mode=max
         build-args: ${{ steps.vars.outputs.build_arguments }}
+        provenance: false
 
     - name: Checkout Action repo to pass tests
       uses: actions/checkout@v4


### PR DESCRIPTION
Apparently GHCR isn't yet compatible with buildx provenance.  Disable for now.