### PR TITLE
feat: parameters, cleanup and codeowners

### DIFF
--- a/.github/codeowners
+++ b/.github/codeowners
@@ -1,0 +1,7 @@
+# Matched against repo root (asterisk)
+*       @mishraomp @paulushcgcj @DerekRoberts
+
+# Matched against directories
+# /.github/workflows/       @mishraomp @paulushcgcj @DerekRoberts
+
+# See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners

--- a/.github/workflows/pr-close.yml
+++ b/.github/workflows/pr-close.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        package: [test-basic, test-advanced]
+        package: [api, backend]
     steps:
       - uses: shrink/actions-docker-registry-tag@v3
         with:

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Only GitHub Container Registry (ghcr.io) is supported so far.
     build_context: ./frontend
 
     # Sets the Dockerfile with path
-    # Optional, defaults to the package name's folder
+    # Optional, defaults to {package}/Dockerfile or {build_context}/Dockerfile
     build_file: ./frontend/Dockerfile
 
     # Number of packages to keep if cleaning up previous builds

--- a/action.yml
+++ b/action.yml
@@ -28,6 +28,7 @@ inputs:
   ### Usually a bad idea / not recommended
   build_args:
     description: A list of build-time variables, generally not adviseable
+    value: "BUILDKIT_INLINE_CACHE=1"
   diff_branch:
     description: Branch to diff against
     default: ${{ github.event.repository.default_branch }}
@@ -72,13 +73,6 @@ runs:
           echo "build_file=${{ inputs.package }}/Dockerfile" >> $GITHUB_OUTPUT
         else
           echo "build_file=${{ inputs.build_file }}" >> $GITHUB_OUTPUT
-        fi
-
-        # Use inputs.build_args unless an override has been provided
-        if [ -z ${{ inputs.build_args }} ]; then
-          echo "build_arguments=BUILDKIT_INLINE_CACHE=1" >> $GITHUB_OUTPUT
-        else
-          echo "build_arguments=${{ inputs.build_args }}" >> $GITHUB_OUTPUT
         fi
 
         # Bug - Docker build hates images with capital letters
@@ -170,7 +164,7 @@ runs:
         tags: ${{ steps.vars.outputs.tags }}
         cache-from: type=gha
         cache-to: type=gha,mode=max
-        build-args: ${{ steps.vars.outputs.build_arguments }}
+        build-args: ${{ input.build_args }}
         provenance: false
 
     - name: GHCR Cleanup

--- a/action.yml
+++ b/action.yml
@@ -20,7 +20,6 @@ inputs:
     description: Paths used to trigger a build; e.g. ('./backend/', './frontend/)
   build_context:
     description: Build context, not required for self-contained package/default directory
-    value: ${{ inputs.package }}
   build_file:
     description: Dockerfile with path, not required for self-contained package/default directory
   keep_versions:
@@ -62,9 +61,16 @@ runs:
       run: |
         # Inputs and variables
 
-        # Use inputs.package/Dockerfile as build_file unless an override has been provided
+        # Use package folder as build_context unless an override has been provided
+        if [ -z ${{ inputs.build_context }} ]; then
+          echo "build_context=${{ inputs.package }}" >> $GITHUB_OUTPUT
+        else
+          echo "build_context=${{ inputs.build_context }}" >> $GITHUB_OUTPUT
+        fi
+
+        # Use BUILD_CONTEXT/Dockerfile as build_file unless an override has been provided
         if [ -z ${{ inputs.build_file }} ]; then
-          echo "build_file=${{ inputs.package }}/Dockerfile" >> $GITHUB_OUTPUT
+          echo "build_file=${BUILD_CONTEXT}/Dockerfile" >> $GITHUB_OUTPUT
         else
           echo "build_file=${{ inputs.build_file }}" >> $GITHUB_OUTPUT
         fi

--- a/action.yml
+++ b/action.yml
@@ -20,6 +20,7 @@ inputs:
     description: Paths used to trigger a build; e.g. ('./backend/', './frontend/)
   build_context:
     description: Build context, not required for self-contained package/default directory
+    value: ${{ inputs.package }}
   build_file:
     description: Dockerfile with path, not required for self-contained package/default directory
   keep_versions:
@@ -60,13 +61,6 @@ runs:
       shell: bash
       run: |
         # Inputs and variables
-
-        # Use package folder as build_context unless an override has been provided
-        if [ -z ${{ inputs.build_context }} ]; then
-          echo "build_context=${{ inputs.package }}" >> $GITHUB_OUTPUT
-        else
-          echo "build_context=${{ inputs.build_context }}" >> $GITHUB_OUTPUT
-        fi
 
         # Use inputs.package/Dockerfile as build_file unless an override has been provided
         if [ -z ${{ inputs.build_file }} ]; then

--- a/action.yml
+++ b/action.yml
@@ -158,7 +158,7 @@ runs:
         tags: ${{ steps.vars.outputs.tags }}
         cache-from: type=gha
         cache-to: type=gha,mode=max
-        build-args: ${{ input.build_args }}
+        build-args: ${{ inputs.build_args }}
         provenance: false
 
     - name: GHCR Cleanup

--- a/action.yml
+++ b/action.yml
@@ -165,7 +165,6 @@ runs:
         cache-from: type=gha
         cache-to: type=gha,mode=max
         build-args: ${{ inputs.build_args }}
-        provenance: false
 
     - name: GHCR Cleanup
       if: ${{ inputs.keep_versions }}

--- a/action.yml
+++ b/action.yml
@@ -68,9 +68,9 @@ runs:
           echo "build_context=${{ inputs.build_context }}" >> $GITHUB_OUTPUT
         fi
 
-        # Use BUILD_CONTEXT/Dockerfile as build_file unless an override has been provided
+        # Use build_context/Dockerfile as build_file unless an override has been provided
         if [ -z ${{ inputs.build_file }} ]; then
-          echo "build_file=${BUILD_CONTEXT}/Dockerfile" >> $GITHUB_OUTPUT
+          echo "build_file=${build_context}/Dockerfile" >> $GITHUB_OUTPUT
         else
           echo "build_file=${{ inputs.build_file }}" >> $GITHUB_OUTPUT
         fi
@@ -141,7 +141,7 @@ runs:
         target: ${{ inputs.tag_fallback }}
         tags: ${{ inputs.tag }}
 
-    # If a build is required, then build and push!
+    # If a build is required, then login, build and push!
     - name: Set up Docker Buildx
       if: steps.build.outputs.triggered == 'true'
       uses: docker/setup-buildx-action@v3
@@ -166,6 +166,7 @@ runs:
         cache-to: type=gha,mode=max
         build-args: ${{ inputs.build_args }}
 
+    # Cleanup if inputs.keep_versions provided
     - name: GHCR Cleanup
       if: ${{ inputs.keep_versions }}
       uses: actions/delete-package-versions@v4
@@ -175,5 +176,7 @@ runs:
         min-versions-to-keep: ${{ inputs.keep_versions }}
         ignore-versions: "${{ inputs.keep_regex }}"
 
-    - name: Checkout Action repo to pass tests
+    # Action repo needs to be present for cleanup/tests
+    - name: Checkout local repo to make sure action.yml is present
+      if: ${{ github.repository }} != ${{ inputs.repository }}
       uses: actions/checkout@v4

--- a/action.yml
+++ b/action.yml
@@ -63,17 +63,19 @@ runs:
 
         # Use package folder as build_context unless an override has been provided
         if [ -z ${{ inputs.build_context }} ]; then
-          echo "build_context=${{ inputs.package }}" >> $GITHUB_OUTPUT
+          BUILD_CONTEXT=${{ inputs.package }}
         else
-          echo "build_context=${{ inputs.build_context }}" >> $GITHUB_OUTPUT
+          BUILD_CONTEXT=${{ inputs.build_context }}
         fi
+        echo "build_context=${BUILD_CONTEXT}" >> $GITHUB_OUTPUT
 
-        # Use build_context/Dockerfile as build_file unless an override has been provided
+        # Use BUILD_CONTEXT/Dockerfile as build_file unless an override has been provided
         if [ -z ${{ inputs.build_file }} ]; then
-          echo "build_file=${build_context}/Dockerfile" >> $GITHUB_OUTPUT
+          BUILD_FILE=${BUILD_CONTEXT}/Dockerfile
         else
-          echo "build_file=${{ inputs.build_file }}" >> $GITHUB_OUTPUT
+          BUILD_FILE=${{ inputs.build_file }}
         fi
+        echo "build_file=${BUILD_FILE}" >> $GITHUB_OUTPUT
 
         # Bug - Docker build hates images with capital letters
         TAGS=$( echo "ghcr.io/${{ github.repository }}/${{ inputs.package }}:${{ inputs.tag }}" | tr '[:upper:]' '[:lower:]' )


### PR DESCRIPTION
- `build_args` can now override "BUILDKIT_INLINE_CACHE=1"
- `build_file` now defaults to `{build_context}/Dockerfile`
- stop disabling provenance attestation (unrelated bug fixed)
- .github/codeowners