### PR TITLE
fix: brackets and allow sha repeats

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -138,7 +138,7 @@ runs:
       id: digest_old
       shell: bash
       run: |
-        DIGEST=$(docker manifest inspect ${{ steps.vars.outputs.tags }} || echo | jq '.manifests[0].digest')
+        DIGEST=$((docker manifest inspect ${{ steps.vars.outputs.tags }} || echo )| jq '.manifests[0].digest')
         echo "digest=${DIGEST}" >> $GITHUB_OUTPUT
 
     # If a build is required, then checkout, login, build and push!
@@ -191,3 +191,12 @@ runs:
         echo "SHA repeat!"
         echo "  New: ${{ steps.digest_new.outputs.digest }}"
         echo "  Old: ${{ steps.digest_old.outputs.digest }}"
+
+    # Summary/debugging
+    - name: Summary
+      shell: bash
+      run: |
+        echo "inputs: ${{ fromJSON(inputs) }}"
+        echo "digest_new: ${{ steps.digest_new.outputs.digest }}"
+        echo "digest_old: ${{ steps.digest_old.outputs.digest }}"
+        echo "triggered: ${{ steps.diff.outputs.triggered }}"

--- a/action.yml
+++ b/action.yml
@@ -187,7 +187,9 @@ runs:
     - name: Summary
       shell: bash
       run: |
-        echo "digest_new: ${{ steps.digest_new.outputs.digest }}"
-        echo "digest_old: ${{ steps.digest_old.outputs.digest }}"
-        echo "triggered: ${{ steps.diff.outputs.triggered }}"
-        # echo "inputs: ${{ fromJSON(inputs) }}"
+        echo "TEST!"
+      # run: |
+      #   echo "inputs: ${{ fromJSON(inputs) }}"
+      #   echo "digest_new: ${{ steps.digest_new.outputs.digest }}"
+      #   echo "digest_old: ${{ steps.digest_old.outputs.digest }}"
+      #   echo "triggered: ${{ steps.diff.outputs.triggered }}"

--- a/action.yml
+++ b/action.yml
@@ -187,9 +187,6 @@ runs:
     - name: Summary
       shell: bash
       run: |
-        echo "inputs: ${{ fromJSON(inputs) }}"
-
-      # run: |
-      #   echo "digest_new: ${{ steps.digest_new.outputs.digest }}"
-      #   echo "digest_old: ${{ steps.digest_old.outputs.digest }}"
-        # echo "triggered: ${{ steps.diff.outputs.triggered }}"
+        echo "digest_new: ${{ steps.digest_new.outputs.digest }}"
+        echo "digest_old: ${{ steps.digest_old.outputs.digest }}"
+        echo "triggered: ${{ steps.diff.outputs.triggered }}"

--- a/action.yml
+++ b/action.yml
@@ -196,8 +196,7 @@ runs:
       if: always()
       shell: bash
       run: |
-        echo "Inputs: ${{ inputs }}"
-        echo -e "\nOutputs:"
-        echo -e "\tdigest: ${{ steps.digest_new.outputs.digest }}"
-        echo -e "\tdigest_old: ${{ steps.digest_old.outputs.digest }}"
-        echo -e "\ttriggered: ${{ steps.diff.outputs.triggered }}"
+        echo "inputs: ${{ fromJSON(inputs) }}"
+        echo "digest_new: ${{ steps.digest_new.outputs.digest }}"
+        echo "digest_old: ${{ steps.digest_old.outputs.digest }}"
+        echo "triggered: ${{ steps.diff.outputs.triggered }}"

--- a/action.yml
+++ b/action.yml
@@ -183,10 +183,9 @@ runs:
         DIGEST=$(docker manifest inspect ${{ steps.vars.outputs.tags }} | jq -r '.manifests[0].digest')
         echo "digest=${DIGEST}" >> $GITHUB_OUTPUT
 
-    # Summary
-    - name: Summary
-      shell: bash
+    - shell: bash
       run: |
+        # Summary
         echo "digest_new: ${{ steps.digest_new.outputs.digest }}"
         echo "digest_old: ${{ steps.digest_old.outputs.digest }}"
         echo "triggered: ${{ steps.diff.outputs.triggered }}"

--- a/action.yml
+++ b/action.yml
@@ -183,20 +183,11 @@ runs:
         DIGEST=$(docker manifest inspect ${{ steps.vars.outputs.tags }} | jq '.manifests[0].digest')
         echo "digest=${DIGEST}" >> $GITHUB_OUTPUT
 
-    # Bug - fail if old and new digests match (e.g. no new image was built)
-    - name: SHA Double-check
-      if: steps.build.outputs.triggered == 'true' && steps.digest_new.outputs.digest == steps.digest_old.outputs.digest
-      shell: bash
-      run: |
-        echo "SHA repeat!"
-        echo "  New: ${{ steps.digest_new.outputs.digest }}"
-        echo "  Old: ${{ steps.digest_old.outputs.digest }}"
-
-    # Summary/debugging
+    # Summary
     - name: Summary
       shell: bash
       run: |
-        echo "inputs: ${{ fromJSON(inputs) }}"
-        echo "digest_new: ${{ steps.digest_new.outputs.digest }}"
-        echo "digest_old: ${{ steps.digest_old.outputs.digest }}"
-        echo "triggered: ${{ steps.diff.outputs.triggered }}"
+        echo 'inputs: ${{ fromJSON(inputs) }}'
+        echo 'digest_new: ${{ steps.digest_new.outputs.digest }}'
+        echo 'digest_old: ${{ steps.digest_old.outputs.digest }}'
+        echo 'triggered: ${{ steps.diff.outputs.triggered }}'

--- a/action.yml
+++ b/action.yml
@@ -188,7 +188,9 @@ runs:
       if: steps.build.outputs.triggered == 'true' && steps.digest_new.outputs.digest == steps.digest_old.outputs.digest
       shell: bash
       run: |
-        echo "SHA collision! New: ${{ steps.digest_new.outputs.digest }}, Old: ${{ steps.digest_old.outputs.digest }}"
+        echo "SHA collision!"
+        echo "  New: ${{ steps.digest_new.outputs.digest }}"
+        echo "  Old: ${{ steps.digest_old.outputs.digest }}"
         exit 1
 
     # Summary/debugging

--- a/action.yml
+++ b/action.yml
@@ -187,7 +187,7 @@ runs:
     - name: Summary
       shell: bash
       run: |
-        echo "inputs: ${{ fromJSON(inputs) }}"
         echo "digest_new: ${{ steps.digest_new.outputs.digest }}"
         echo "digest_old: ${{ steps.digest_old.outputs.digest }}"
         echo "triggered: ${{ steps.diff.outputs.triggered }}"
+        # echo "inputs: ${{ fromJSON(inputs) }}"

--- a/action.yml
+++ b/action.yml
@@ -190,3 +190,11 @@ runs:
       run: |
         echo "SHA collision! New: ${{ steps.digest_new.outputs.digest }}, Old: ${{ steps.digest_old.outputs.digest }}"
         exit 1
+
+    # Summary/debugging
+    - name: Summary
+      if: always()
+      shell: bash
+      run: |
+        echo "Inputs: ${{ inputs }}"
+        echo "Outputs: ${{ outputs }}"

--- a/action.yml
+++ b/action.yml
@@ -197,4 +197,7 @@ runs:
       shell: bash
       run: |
         echo "Inputs: ${{ inputs }}"
-        echo "Outputs: ${{ outputs }}"
+        echo -e "\nOutputs:"
+        echo -e "\tdigest: ${{ steps.digest_new.outputs.digest }}"
+        echo -e "\tdigest_old: ${{ steps.digest_old.outputs.digest }}"
+        echo -e "\ttriggered: ${{ steps.diff.outputs.triggered }}"

--- a/action.yml
+++ b/action.yml
@@ -138,7 +138,7 @@ runs:
       id: digest_old
       shell: bash
       run: |
-        DIGEST=$((docker manifest inspect ${{ steps.vars.outputs.tags }} || echo )| jq '.manifests[0].digest')
+        DIGEST=$((docker manifest inspect ${{ steps.vars.outputs.tags }} || echo )| jq -r '.manifests[0].digest')
         echo "digest=${DIGEST}" >> $GITHUB_OUTPUT
 
     # If a build is required, then checkout, login, build and push!
@@ -180,14 +180,14 @@ runs:
       id: digest_new
       shell: bash
       run: |
-        DIGEST=$(docker manifest inspect ${{ steps.vars.outputs.tags }} | jq '.manifests[0].digest')
+        DIGEST=$(docker manifest inspect ${{ steps.vars.outputs.tags }} | jq -r '.manifests[0].digest')
         echo "digest=${DIGEST}" >> $GITHUB_OUTPUT
 
     # Summary
     - name: Summary
       shell: bash
       run: |
-        echo 'inputs: ${{ fromJSON(inputs) }}'
-        echo 'digest_new: ${{ steps.digest_new.outputs.digest }}'
-        echo 'digest_old: ${{ steps.digest_old.outputs.digest }}'
-        echo 'triggered: ${{ steps.diff.outputs.triggered }}'
+        echo "inputs: ${{ fromJSON(inputs) }}"
+        echo "digest_new: ${{ steps.digest_new.outputs.digest }}"
+        echo "digest_old: ${{ steps.digest_old.outputs.digest }}"
+        echo "triggered: ${{ steps.diff.outputs.triggered }}"

--- a/action.yml
+++ b/action.yml
@@ -187,9 +187,9 @@ runs:
     - name: Summary
       shell: bash
       run: |
-        echo "TEST!"
+        echo "inputs: ${{ fromJSON(inputs) }}"
+        echo "triggered: ${{ steps.diff.outputs.triggered }}"
+
       # run: |
-      #   echo "inputs: ${{ fromJSON(inputs) }}"
       #   echo "digest_new: ${{ steps.digest_new.outputs.digest }}"
       #   echo "digest_old: ${{ steps.digest_old.outputs.digest }}"
-      #   echo "triggered: ${{ steps.diff.outputs.triggered }}"

--- a/action.yml
+++ b/action.yml
@@ -188,8 +188,8 @@ runs:
       shell: bash
       run: |
         echo "inputs: ${{ fromJSON(inputs) }}"
-        echo "triggered: ${{ steps.diff.outputs.triggered }}"
 
       # run: |
       #   echo "digest_new: ${{ steps.digest_new.outputs.digest }}"
       #   echo "digest_old: ${{ steps.digest_old.outputs.digest }}"
+        # echo "triggered: ${{ steps.diff.outputs.triggered }}"

--- a/action.yml
+++ b/action.yml
@@ -138,7 +138,7 @@ runs:
       id: digest_old
       shell: bash
       run: |
-        DIGEST=$(docker manifest inspect ${{ steps.vars.outputs.tags }} || echo | jq '.manifests[0].digest')
+        DIGEST=$((docker manifest inspect ${{ steps.vars.outputs.tags }} || echo) | jq '.manifests[0].digest')
         echo "digest=${DIGEST}" >> $GITHUB_OUTPUT
 
     # If a build is required, then checkout, login, build and push!

--- a/action.yml
+++ b/action.yml
@@ -138,7 +138,7 @@ runs:
       id: digest_old
       shell: bash
       run: |
-        DIGEST=$((docker manifest inspect ${{ steps.vars.outputs.tags }} || echo) | jq '.manifests[0].digest')
+        DIGEST=$(docker manifest inspect ${{ steps.vars.outputs.tags }} || echo | jq '.manifests[0].digest')
         echo "digest=${DIGEST}" >> $GITHUB_OUTPUT
 
     # If a build is required, then checkout, login, build and push!
@@ -188,17 +188,6 @@ runs:
       if: steps.build.outputs.triggered == 'true' && steps.digest_new.outputs.digest == steps.digest_old.outputs.digest
       shell: bash
       run: |
-        echo "SHA collision!"
+        echo "SHA repeat!"
         echo "  New: ${{ steps.digest_new.outputs.digest }}"
         echo "  Old: ${{ steps.digest_old.outputs.digest }}"
-        exit 1
-
-    # Summary/debugging
-    - name: Summary
-      if: always()
-      shell: bash
-      run: |
-        echo "inputs: ${{ fromJSON(inputs) }}"
-        echo "digest_new: ${{ steps.digest_new.outputs.digest }}"
-        echo "digest_old: ${{ steps.digest_old.outputs.digest }}"
-        echo "triggered: ${{ steps.diff.outputs.triggered }}"


### PR DESCRIPTION
Fix missing brackets around docker manifest inspect logic.  Also allow SHAs to be reused, since there are plenty of times this should be happening (e.g. fully cached build).