### PR TITLE
feat: add build envars to Dockerfiles and images

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -146,13 +146,13 @@ runs:
       with:
         repository: ${{ inputs.repository }}
 
-    # Add envars to Dockerfile
-    - name: Add build args and envars
+    - name: Add build envars to Dockerfile
       if: steps.build.outputs.triggered == 'true'
       env:
         dockerfile: ${{ steps.vars.outputs.build_file }}
       shell: bash
       run: |
+        # Add build envars to Dockerfile
         echo "ENV BUILDER_IMAGE=ghcr.io/${{ github.repository }}/${{ inputs.package }}:${{ inputs.tag }}" >> ${{ env.dockerfile }}
         echo "ENV BUILDER_PACKAGE=${{ inputs.package }}" >> ${{ env.dockerfile }}
         echo "ENV BUILDER_REPO=${{ github.repository }}" >> ${{ env.dockerfile }}

--- a/action.yml
+++ b/action.yml
@@ -149,12 +149,14 @@ runs:
     # Add envars to Dockerfile
     - name: Add build args and envars
       if: steps.build.outputs.triggered == 'true'
+      env:
+        dockerfile: ${{ steps.vars.outputs.build_file }}
       shell: bash
       run: |
-        echo "BUILDER_IMAGE=ghcr.io/${{ github.repository }}/${{ github.package }}:${{ inputs.target }}" >> $DOCKERFILE 
-        echo "BUILDER_PACKAGE=${{ inputs.package }}" >> $DOCKERFILE
-        echo "BUILDER_REPO=${{ github.repository }}" >> $DOCKERFILE
-        echo "BUILDER_TAG=${{ inputs.target }}" >> $DOCKERFILE
+        echo "BUILDER_IMAGE=ghcr.io/${{ github.repository }}/${{ github.package }}:${{ inputs.tag }}" >> ${{ env.dockerfile }}
+        echo "BUILDER_PACKAGE=${{ inputs.package }}" >> ${{ env.dockerfile }}
+        echo "BUILDER_REPO=${{ github.repository }}" >> ${{ env.dockerfile }}
+        echo "BUILDER_TAG=${{ inputs.tag }}" >> ${{ env.dockerfile }}
 
     - name: Set up Docker Buildx
       if: steps.build.outputs.triggered == 'true'

--- a/action.yml
+++ b/action.yml
@@ -153,10 +153,10 @@ runs:
         dockerfile: ${{ steps.vars.outputs.build_file }}
       shell: bash
       run: |
-        echo "BUILDER_IMAGE=ghcr.io/${{ github.repository }}/${{ github.package }}:${{ inputs.tag }}" >> ${{ env.dockerfile }}
-        echo "BUILDER_PACKAGE=${{ inputs.package }}" >> ${{ env.dockerfile }}
-        echo "BUILDER_REPO=${{ github.repository }}" >> ${{ env.dockerfile }}
-        echo "BUILDER_TAG=${{ inputs.tag }}" >> ${{ env.dockerfile }}
+        echo "ENV BUILDER_IMAGE=ghcr.io/${{ github.repository }}/${{ github.package }}:${{ inputs.tag }}" >> ${{ env.dockerfile }}
+        echo "ENV BUILDER_PACKAGE=${{ inputs.package }}" >> ${{ env.dockerfile }}
+        echo "ENV BUILDER_REPO=${{ github.repository }}" >> ${{ env.dockerfile }}
+        echo "ENV BUILDER_TAG=${{ inputs.tag }}" >> ${{ env.dockerfile }}
 
     - name: Set up Docker Buildx
       if: steps.build.outputs.triggered == 'true'

--- a/action.yml
+++ b/action.yml
@@ -146,6 +146,16 @@ runs:
       with:
         repository: ${{ inputs.repository }}
 
+    # Add envars to Dockerfile
+    - name: Add build args and envars
+      if: steps.build.outputs.triggered == 'true'
+      shell: bash
+      run: |
+        echo "BUILDER_IMAGE=ghcr.io/${{ github.repository }}/${{ github.package }}:${{ inputs.target }}" >> $DOCKERFILE 
+        echo "BUILDER_PACKAGE=${{ inputs.package }}" >> $DOCKERFILE
+        echo "BUILDER_REPO=${{ github.repository }}" >> $DOCKERFILE
+        echo "BUILDER_TAG=${{ inputs.target }}" >> $DOCKERFILE
+
     - name: Set up Docker Buildx
       if: steps.build.outputs.triggered == 'true'
       uses: docker/setup-buildx-action@v3
@@ -156,7 +166,7 @@ runs:
       with:
         registry: ghcr.io
         username: ${{ github.actor }}
-        password: ${{ inputs.token }}
+        password: ${{ inputs.token }} 
 
     - name: Build and push ${{ inputs.package }} Docker image
       if: steps.build.outputs.triggered == 'true'

--- a/action.yml
+++ b/action.yml
@@ -153,7 +153,7 @@ runs:
         dockerfile: ${{ steps.vars.outputs.build_file }}
       shell: bash
       run: |
-        echo "ENV BUILDER_IMAGE=ghcr.io/${{ github.repository }}/${{ github.package }}:${{ inputs.tag }}" >> ${{ env.dockerfile }}
+        echo "ENV BUILDER_IMAGE=ghcr.io/${{ github.repository }}/${{ inputs.package }}:${{ inputs.tag }}" >> ${{ env.dockerfile }}
         echo "ENV BUILDER_PACKAGE=${{ inputs.package }}" >> ${{ env.dockerfile }}
         echo "ENV BUILDER_REPO=${{ github.repository }}" >> ${{ env.dockerfile }}
         echo "ENV BUILDER_TAG=${{ inputs.tag }}" >> ${{ env.dockerfile }}


### PR DESCRIPTION
This is the exciting part.
```
env:
  dockerfile: ${{ steps.vars.outputs.build_file }}
shell: bash
run: |
  # Add build envars to Dockerfile
  echo "ENV BUILDER_IMAGE=ghcr.io/${{ github.repository }}/${{ inputs.package }}:${{ inputs.tag }}" >> ${{ env.dockerfile }}
  echo "ENV BUILDER_PACKAGE=${{ inputs.package }}" >> ${{ env.dockerfile }}
  echo "ENV BUILDER_REPO=${{ github.repository }}" >> ${{ env.dockerfile }}
  echo "ENV BUILDER_TAG=${{ inputs.tag }}" >> ${{ env.dockerfile }}
```