### PR TITLE
fix: SBOM generation handling, permission checks

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -218,7 +218,7 @@ runs:
         set +e -u
 
         IMAGE="ghcr.io/${{ steps.vars.outputs.image_path }}@${{ steps.build_and_push.outputs.digest }}"
-        PACKAGE_SANITIZED=$(echo "${{ inputs.package }}" | tr '/' '-')
+        PACKAGE_SANITIZED=$(echo "${{ inputs.package }}" | tr '/:' '-' | tr -d ' ')
         echo "package_sanitized=${PACKAGE_SANITIZED}" >> $GITHUB_OUTPUT
 
         mkdir -p sboms
@@ -234,16 +234,16 @@ runs:
         CYCLONEDX_FILE="sboms/${PACKAGE_SANITIZED}-cyclonedx.json"
         SPDX_FILE="sboms/${PACKAGE_SANITIZED}-spdx.json"
         stderr_file=$(mktemp)
-        
+
         syft scan "$IMAGE" \
           -o cyclonedx-json="$CYCLONEDX_FILE" \
           -o spdx-json="$SPDX_FILE" \
           2>"$stderr_file"
-        
+
         exit_code=$?
         stderr=$(cat "$stderr_file")
         rm -f "$stderr_file"
-        
+
         if [ $exit_code -eq 0 ]; then
           if [ -n "$stderr" ]; then
             echo "::notice::Syft warnings: ${stderr}"


### PR DESCRIPTION
## Problem
Downstream repositories were failing when SBOM generation encountered insufficient privileges (missing id-token:write and attestations:write permissions). The workflow would fail instead of continuing gracefully.

## Solution
- Added `continue-on-error: true` to SBOM generation step to prevent workflow failures
- Improved error detection with specific permission-related error messages
- Fixed directory handling for nested package names (e.g. `airbyte/airbyte-web`)
- Changed upload-artifact to warn instead of error when no files found
- Added `continue-on-error: true` to upload step for graceful degradation
- Provide actionable guidance about required permissions
- Display actual error messages instead of hiding them with `2>/dev/null`

## Changes
- SBOM generation now continues even if it fails due to permissions
- Users get clear warnings about missing permissions with actionable guidance
- Upload step warns instead of errors when no SBOM files are found
- Better error messages help diagnose issues

Fixes the issue where workflows would fail completely when SBOM generation couldn't proceed due to insufficient permissions.