### PR TITLE
fix: Don't treat cancelled jobs as failures in pr-open workflow

### DIFF
--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -184,8 +184,8 @@ jobs:
     if: always() && needs.fork-detection-skip.result != 'failure'
     runs-on: ubuntu-24.04
     steps:
-      - if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
-        run: echo "At least one job has failed or was cancelled." && exit 1
+      - if: contains(needs.*.result, 'failure')
+        run: echo "At least one job has failed." && exit 1
       - if: needs.fork-detection-skip.result == 'skipped' && github.event_name == 'pull_request'
         run: |
           echo "Note: fork-detection-skip job was skipped (only runs on pull_request_target events)"


### PR DESCRIPTION
## Summary
Remove `|| contains(needs.*.result, 'cancelled')` check from the results job.

## Problem
When a PR is opened, both `pull_request` and `pull_request_target` events fire simultaneously. Since they share the same concurrency group, GitHub cancels one of the runs. The `results` job was treating cancelled jobs as failures, causing spurious failures.

## Solution
Cancelled jobs aren't failures - they're just concurrency victims. This fix accepts that one run gets cancelled (which is fine) but doesn't treat cancellation as a failure.