### PR TITLE
fix: Use vars step for lowercase (action syntax)

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -312,8 +312,8 @@ runs:
         tags: ${{ steps.tags.outputs.final_tags }}
         labels: ${{ steps.tags.outputs.labels }}
         annotations: ${{ steps.tags.outputs.annotations }}
-        cache-from: type=registry,ref=ghcr.io/${{ github.repository,, }}:buildcache
-        cache-to: type=registry,ref=ghcr.io/${{ github.repository,, }}:buildcache,mode=max
+        cache-from: type=registry,ref=ghcr.io/${{ steps.vars.outputs.image_path }}:buildcache
+        cache-to: type=registry,ref=ghcr.io/${{ steps.vars.outputs.image_path }}:buildcache,mode=max
         build-args: ${{ inputs.build_args }}
         secrets: ${{ inputs.secrets }}
 


### PR DESCRIPTION
## Summary
Fixes the registry cache to use `${{ steps.vars.outputs.image_path }}` instead of `${{ github.repository,, }}`.

## Problem
The `,,` lowercase modifier syntax doesn't work in composite GitHub Actions:
```
Unexpected symbol: ','. Located at position 18 within expression: github.repository,,
```

The vars step already lowercases the path via `${image_path,,}` in bash, so we reuse that.

## Change
```yaml
- cache-from: type=registry,ref=ghcr.io/${{ github.repository,, }}:buildcache
+ cache-from: type=registry,ref=ghcr.io/${{ steps.vars.outputs.image_path }}:buildcache
```