### PR TITLE
fix: Test PR code with pull_request not pull_request_target

### DIFF
--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -1,13 +1,14 @@
 name: PR
 
 on:
-  pull_request_target:
+  pull_request:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 permissions:
+  contents: read
   attestations: write
   id-token: write
   packages: write

--- a/action.yml
+++ b/action.yml
@@ -312,8 +312,8 @@ runs:
         tags: ${{ steps.tags.outputs.final_tags }}
         labels: ${{ steps.tags.outputs.labels }}
         annotations: ${{ steps.tags.outputs.annotations }}
-        cache-from: type=registry,ref=ghcr.io/${{ github.repository,, }}:buildcache
-        cache-to: type=registry,ref=ghcr.io/${{ github.repository,, }}:buildcache,mode=max
+        cache-from: type=registry,ref=ghcr.io/${{ steps.vars.outputs.image_path }}:buildcache
+        cache-to: type=registry,ref=ghcr.io/${{ steps.vars.outputs.image_path }}:buildcache,mode=max
         build-args: ${{ inputs.build_args }}
         secrets: ${{ inputs.secrets }}
 


### PR DESCRIPTION
Changes workflow to use pull_request instead of pull_request_target so tests run on PR branch code.