### PR TITLE
fix(inputs): switch optional input to github_token

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Only GitHub Container Registry (ghcr.io) is supported so far.
     sbom: 'true'
 
     # Specify token (GH or PAT), instead of inheriting one from the calling workflow
-    token: ${{ secrets.GITHUB_TOKEN }}
+    github_token: ${{ secrets.GITHUB_TOKEN }}
 
     # Specify username for registry login; defaults to github.actor
     # Useful when using a PAT or service account
@@ -133,13 +133,13 @@ This action supports building from and pushing to private repositories.
 ### Authentication
 
 - **Same Repository/Organization**: By default, the action uses the automatic `GITHUB_TOKEN`. Ensure your workflow has `contents: read` and `packages: write` permissions.
-- **Cross-Organization**: To build from a private repository in a different organization, provide a **Personal Access Token (PAT)** with `repo` scope via the `token` input and specify the associated `username`.
+- **Cross-Organization**: To build from a private repository in a different organization, provide a **Personal Access Token (PAT)** with `repo` scope via the `github_token` input and specify the associated `username`.
 
 ### Security
 
 To prevent credential leakage, this action:
 - Uses `persist-credentials: false` during all checkout steps.
-- Performs a clean registry login using the provided `username` and `token` before any manifest or build operations.
+- Performs a clean registry login using the provided `username` and `github_token` before any manifest or build operations.
 - Follows the principle of least privilege by **not** automatically injecting `GITHUB_TOKEN` into the Docker build process. If your build needs a token (e.g., to pull private packages), you must explicitly provide it via the `secrets` input.
 
 
@@ -178,7 +178,7 @@ builds:
           ${{ github.sha }}
           latest
         tag_fallback: test
-        token: ${{ secrets.GITHUB_TOKEN }}
+        github_token: ${{ secrets.GITHUB_TOKEN }}
         triggers: ('frontend/')
 ```
 
@@ -206,7 +206,7 @@ builds:
         tags: ${{ github.event.number }}
         tag_fallback: test
         repository: bcgov/nr-quickstart-typescript
-        token: ${{ secrets.GITHUB_TOKEN }}
+        github_token: ${{ secrets.GITHUB_TOKEN }}
         triggers: ${{ matrix.triggers }}
 
 ```

--- a/action.yml
+++ b/action.yml
@@ -42,7 +42,7 @@ inputs:
   repository:
     description: Non-default repo to clone
     default: ${{ github.repository }}
-  token:
+  github_token:
     description: Specify token (GH or PAT), instead of inheriting one from the calling workflow
     default: ${{ github.token }}
   username:
@@ -160,7 +160,7 @@ runs:
       with:
         registry: ghcr.io
         username: ${{ inputs.username }}
-        password: ${{ inputs.token }}
+        password: ${{ inputs.github_token }}
 
     # Check if a build is required (steps.build.outputs.triggered=true|false)
     - name: Check for builds
@@ -220,7 +220,7 @@ runs:
         target: ${{ inputs.tag_fallback }}
         tags: |
           ${{ inputs.tags }}
-        token: ${{ inputs.token }}
+        token: ${{ inputs.github_token }}
 
 
     # Checkout code for building - external repo (use default branch)
@@ -229,7 +229,7 @@ runs:
       uses: actions/checkout@v6
       with:
         repository: ${{ inputs.repository }}
-        token: ${{ inputs.token }}
+        token: ${{ inputs.github_token }}
         persist-credentials: false
         path: .builder-context
         clean: false
@@ -242,7 +242,7 @@ runs:
       with:
         repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
         ref: ${{ github.event.pull_request.head.sha || github.ref }}
-        token: ${{ inputs.token }}
+        token: ${{ inputs.github_token }}
         persist-credentials: false
         path: .builder-context
         clean: false

--- a/action.yml
+++ b/action.yml
@@ -148,7 +148,7 @@ runs:
     # against another repository's branch is not meaningful in this context.
     - id: diff
       if: inputs.repository == github.repository
-      uses: bcgov/action-diff-triggers@4abfcb211f5816d654d1c5a417e5431a2c4a5379 # v1.1.1
+      uses: bcgov/action-diff-triggers@a80e4b3cf77b7e05f84e74030e3bfa08b717a574 # v1.2.1
       with:
         triggers: ${{ inputs.triggers }}
         ref: ${{ inputs.diff_branch }}


### PR DESCRIPTION
This PR renames the 'token' input parameter to 'github_token' to align with standard GitHub Actions conventions and avoid naming ambiguity.